### PR TITLE
Use Set instead of Array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export default function mitt(all) {
 	// Get or create a named handler list
 	function list(type) {
 		let t = type.toLowerCase();
-		return all[t] || (all[t] = []);
+		return all[t] || (all[t] = new Set());
 	}
 
 	return {
@@ -20,7 +20,7 @@ export default function mitt(all) {
 		 *	@memberof mitt
 		 */
 		on(type, handler) {
-			list(type).push(handler);
+			list(type).add(handler);
 		},
 
 		/** Remove an event handler for the given type.
@@ -29,9 +29,7 @@ export default function mitt(all) {
 		 *	@memberof mitt
 		 */
 		off(type, handler) {
-			let e = list(type),
-				i = e.indexOf(handler);
-			if (~i) e.splice(i, 1);
+			list(type).delete(handler);
 		},
 
 		/** Invoke all handlers for the given type.
@@ -41,7 +39,7 @@ export default function mitt(all) {
 		 *	@memberof mitt
 		 */
 		emit(type, event) {
-			list('*').concat(list(type)).forEach( f => { f(event); });
+			new Set([...list('*'), ...list(type)]).forEach( f => { f(event); });
 		}
 	};
 }

--- a/test/index.js
+++ b/test/index.js
@@ -29,17 +29,16 @@ describe('mitt', () => {
 				let foo = () => {};
 				inst.on('foo', foo);
 
-				expect(events).to.have.property('foo').that.deep.equals([foo]);
+				expect(events).to.have.property('foo').that.deep.equals(new Set([foo]));
 			});
 
 			it('should append handler for existing type', () => {
 				let foo = () => {};
 				let bar = () => {};
 				inst.on('foo', foo);
-				inst.on('foo', foo);
 				inst.on('foo', bar);
 
-				expect(events).to.have.property('foo').that.deep.equals([foo, foo, bar]);
+				expect(events).to.have.property('foo').that.deep.equals(new Set([foo, foo, bar]));
 			});
 
 			it('should normalize case', () => {
@@ -48,9 +47,9 @@ describe('mitt', () => {
 				inst.on('Bar', foo);
 				inst.on('baz:baT!', foo);
 
-				expect(events).to.have.property('foo').that.deep.equals([foo]);
-				expect(events).to.have.property('bar').that.deep.equals([foo]);
-				expect(events).to.have.property('baz:bat!').that.deep.equals([foo]);
+				expect(events).to.have.property('foo').that.deep.equals(new Set([foo]));
+				expect(events).to.have.property('bar').that.deep.equals(new Set([foo]));
+				expect(events).to.have.property('baz:bat!').that.deep.equals(new Set([foo]));
 			});
 		});
 
@@ -63,28 +62,17 @@ describe('mitt', () => {
 
 			it('should remove handler for type', () => {
 				let foo = () => {};
-				events.foo = [foo];
+				inst.on('foo', foo);
 				inst.off('foo', foo);
 
-				expect(events).to.have.property('foo').that.is.empty;
-			});
-
-			it('should remove only one handler for dupes', () => {
-				let foo = () => {};
-				events.foo = [foo, foo];
-
-				inst.off('foo', foo);
-				expect(events).to.have.property('foo').that.deep.equals([foo]);
-
-				inst.off('foo', foo);
 				expect(events).to.have.property('foo').that.is.empty;
 			});
 
 			it('should normalize case', () => {
 				let foo = () => {};
-				events.foo = [foo];
-				events.bar = [foo];
-				events['baz:bat!'] = [foo];
+				inst.on('foo', foo);
+				inst.on('bar', foo);
+				inst.on('baz:bat!', foo);
 
 				inst.off('FOO', foo);
 				inst.off('Bar', foo);


### PR DESCRIPTION
Pros:

 * Smaller size (181b)
 * Easier to deal with handler's deletion
 * Make sure the same handlers in `*` and in other types are called only once
 * Prevent unexpected handlers duplication in one type

Cons:

 * Removes the support of duplicated handlers in the same list. Personally I consider this as a pros because this behavior always leads to unexpected redundant handler calls when you don't expect it at all. Once you run into this issue, you start to wrapping code into conditions to prevent unnecessary registrations.