### PR TITLE
Update editorconfig rules on javascript files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,10 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.js]
+indent_style = space
+indent_size = 4
+
 [{package.json,.*rc,*.yml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Javascript code conventions added on the .editorconfig

Indent is 4 spaces