### PR TITLE
Fix typo in package.json `homepage` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eventemitter",
     "pubsub"
   ],
-  "homepage": "httsp://github.com/developit/mitt",
+  "homepage": "https://github.com/developit/mitt",
   "authors": [
     "Jason Miller <jason@developit.ca>"
   ],


### PR DESCRIPTION
Hi there, thanks for making this awesome little module 🌮 

Minor fix here. The `homepage` url started with `httsp` instead of `https`, and this simply makes that quick fix.