### PR TITLE
Breadth-first events emitting instead of depth-first

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export default function mitt(all) {
 		 *	@memberof mitt
 		 */
 		emit(type, event) {
-			list('*').concat(list(type)).forEach( f => { f(event); });
+			list('*').concat(list(type)).forEach( f => { setTimeout(f, 0, event); });
 		}
 	};
 }


### PR DESCRIPTION
Hi!
First of all, thank you for this tiny Event emitter :) In general, it works fine, but in some cases (eg. circular dependency) it can block the Event loop. 
Look at this code snippet:
```js
import mitt from 'mitt'
let emitter = mitt();
emitter.on('foo', e => emitter.emit('bar'));
emitter.on('bar', e => emitter.emit('baz'));
emitter.on('baz', e => emitter.emit('foo'));
emitter.on('quux', e => console.log("I'll never run"));
emitter.emit('foo');
emitter.emit('quux');
```
