### PR TITLE
Return unsub function from on()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,10 @@ type EventHandlerMap = {
  *  @returns {Mitt}
  */
 export default function mitt(all: EventHandlerMap) {
-	all = all || Object.create(null);
+	all = all || {};
+	let instance;
 
-	return {
+	return instance = {
 		/**
 		 * Register an event handler for the given type.
 		 *
@@ -26,7 +27,9 @@ export default function mitt(all: EventHandlerMap) {
 		 * @memberOf mitt
 		 */
 		on(type: string, handler: EventHandler) {
-			(all[type] || (all[type] = [])).push(handler);
+			var arr = all[type] = all[type] || [];
+			arr.push(handler);
+			return instance.off.bind(instance, type, handler);
 		},
 
 		/**
@@ -38,8 +41,8 @@ export default function mitt(all: EventHandlerMap) {
 		 * @memberOf mitt
 		 */
 		off(type: string, handler: EventHandler) {
-			let e = all[type] || (all[type] = []);
-			e.splice(e.indexOf(handler) >>> 0, 1);
+			var arr = all[type] || [];
+			arr.splice(arr.indexOf(handler) >>> 0, 1);
 		},
 
 		/**

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,13 @@ describe('mitt#', () => {
 			expect(events).to.not.have.property('bar');
 			expect(events).to.have.property('baz:baT!').that.deep.equals([foo]);
 		});
+
+		it('should return unsubscribe function', () => {
+			let foo = () => {};
+			let off = inst.on('foo', foo);
+
+			expect(off).to.be.a('function');
+		});
 	});
 
 	describe('off()', () => {
@@ -90,6 +97,17 @@ describe('mitt#', () => {
 			expect(events).to.have.property('Bar').that.is.empty;
 			expect(events).to.not.have.property('bar');
 			expect(events).to.have.property('baz:baT!').that.is.empty;
+		});
+
+		it('should remove handler if unsubscribe is called', () => {
+			let foo = () => {};
+			let off = inst.on('foo', foo);
+
+			expect(events).to.have.property('foo').that.deep.equals([foo]);
+
+			off();
+
+			expect(events).to.have.property('foo').that.is.empty;
 		});
 	});
 


### PR DESCRIPTION
195b. Forked from #1.

- Don't assign `all[type]` in `.off()`
- Use a slightly more space-efficient assignment of`all[type]` in `.on()` (no parens).
- Return a bound splice from `.on()`.

The one thing I can't figure out is the why the "off() should normalize case" test is failing now. In fact, I don't see how it ever worked.
