### PR TITLE
Fixing API documentation header

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Mitt: Tiny (~200b) functional event emitter / pubsub.
 
 Returns **Mitt** 
 
-#### emit
+### emit
 
 Invoke all handlers for the given type.
 If present, `"*"` handlers are invoked after type-matched handlers.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Mitt: Tiny (~200b) functional event emitter / pubsub.
 
 Returns **Mitt** 
 
-### emit
+#### emit
 
 Invoke all handlers for the given type.
 If present, `"*"` handlers are invoked after type-matched handlers.

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ export default function mitt(all: EventHandlerMap) {
 		 *
 		 * @param {String} type  The event type to invoke
 		 * @param {Any} [evt]  Any value (object is recommended and powerful), passed to each handler
-		 * @memberof mitt
+		 * @memberOf mitt
 		 */
 		emit(type: string, evt: any) {
 			(all[type] || []).map((handler) => { handler(evt); });


### PR DESCRIPTION
Noticed that the `emit()` method didn't have the same header sizing as other methods.