### PR TITLE
Remove all listeners when .off gets called without a type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,9 @@ export default function mitt(all: EventHandlerMap) {
 		 * @memberOf mitt
 		 */
 		off(type: string, handler: EventHandler) {
-			if (all[type]) {
+			if (!type) {
+				all = Object.create(null);
+			} else if (all[type]) {
 				all[type].splice(all[type].indexOf(handler) >>> 0, 1);
 			}
 		},

--- a/test/index.js
+++ b/test/index.js
@@ -75,6 +75,28 @@ describe('mitt#', () => {
 			expect(events).to.have.property('foo').that.is.empty;
 		});
 
+		it('should remove all handlers when invoked without type', () => {
+			const onFoo = spy();
+			const onBar = spy();
+
+			inst.on('foo', onFoo);
+			inst.on('bar', onBar);
+
+			inst.emit('foo', 1);
+			inst.emit('foo', 2);
+			inst.emit('bar', 3);
+
+			inst.off();
+
+			inst.emit('foo', 4);
+			inst.emit('foo', 5);
+			inst.emit('bar', 6);
+			inst.emit('bar', 7);
+
+			expect(onFoo).to.have.callCount(2);
+			expect(onBar).to.have.callCount(1);
+		});
+
 		it('should NOT normalize case', () => {
 			let foo = () => {};
 			inst.on('FOO', foo);


### PR DESCRIPTION
fixes #70
```
> npm-run-all --silent clean -p rollup -p minify:* -s docs size

Gzipped Size: 194 B
```