### PR TITLE
Change type of the all property in the constructor

### DIFF
--- a/mitt.d.ts
+++ b/mitt.d.ts
@@ -8,7 +8,7 @@ declare namespace mitt {
 	type Handler = (event?: any) => void;
 
 	interface MittStatic {
-		new(all?: {[key: string]: Handler}): Emitter;
+		new(all?: {[key: string]: Array<Handler>}): Emitter;
 	}
 
 	interface Emitter {


### PR DESCRIPTION
This commit corrects the type of the `all` property in the `mitt` constructor function, such that it properly reflects a list of `Handler` functions rather than a single `Handler` function.

This makes it possible to provide an argument to the `all` property in TypeScript projects without casting the argument to the `any` type and with proper type feedback.