### PR TITLE
Fix Typescript wildcard handler

### DIFF
--- a/mitt.d.ts
+++ b/mitt.d.ts
@@ -6,6 +6,7 @@ declare module "mitt" {
 
 declare namespace mitt {
 	type Handler = (event?: any) => void;
+	type WildcardHandler = (type?: string, event?: any) => void;
 
 	interface MittStatic {
 		new(all?: {[key: string]: Handler}): Emitter;
@@ -21,6 +22,7 @@ declare namespace mitt {
 		 * @memberOf Mitt
 		 */
 		on(type: string, handler: Handler): void;
+		on(type: "*", handler: WildcardHandler): void;
 
 		/**
 		 * Function to call in response to the given event

--- a/mitt.d.ts
+++ b/mitt.d.ts
@@ -33,6 +33,7 @@ declare namespace mitt {
 		 * @memberOf Mitt
 		 */
 		off(type: string, handler: Handler): void;
+		off(type: "*", handler: WildcardHandler): void;
 
 		/**
 		 * Invoke all handlers for the given type.


### PR DESCRIPTION
Currently the below example will generate an error from Typescript since the `Handler` type is used for all calls to `.on` and `.off` and the `Handler` signature does not allow for the event type as the first parameter.

```typescript
import mitt from "mitt";

const emitter = new mitt();

function listenAll(callback: (type: string, event: any) => void) {
	emitter.on('*', callback);
	return () => emitter.off('*', callback);
}
```

I have introduced a `WildcardHandler` type that is expected when the first argument to `.on` or `.off` is `'*'`.

It looks like this is already fixed in the Flow types, but Typescript still has the issue.