### PR TITLE
Improve CommonJS import from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then with a module bundler like [rollup](http://rollupjs.org/) or [webpack](http
 import mitt from 'mitt'
 
 // using CommonJS modules
-var mitt = require('mitt')
+var mitt = require('mitt').default
 ```
 
 The [UMD](https://github.com/umdjs/umd) build is also available on [unpkg](https://unpkg.com):


### PR DESCRIPTION
AFAIK `require('mitt')` won't work by itself, you need to do `require('mitt').default`.

Thanks for the great lib :+1: