### PR TITLE
Save few more bytes?

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,8 @@ export default function mitt(all: EventHandlerMap) {
 		 * @memberOf mitt
 		 */
 		emit(type: string, evt: any) {
-			(all[type] || []).slice().map((handler) => { handler(evt); });
-			(all['*'] || []).slice().map((handler) => { handler(type, evt); });
+			(all[type] || []).slice().map((handler) => handler(evt));
+			(all['*'] || []).slice().map((handler) => handler(type, evt));
 		}
 	};
 }


### PR DESCRIPTION
If you prefer `map` over `forEach` to save few bytes, then you could also remove those brackets (would be surprised if those where removed by minifier since it does not know `handler` returns undefined.)