### PR TITLE
remove unecessary overhead for some performance gains

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,8 @@ export default function mitt(all: EventHandlerMap) {
 		 * @memberOf mitt
 		 */
 		emit(type: string, evt: any) {
-			(all[type] || []).slice().map((handler) => { handler(evt); });
-			(all['*'] || []).slice().map((handler) => { handler(type, evt); });
+			(all[type] || []).forEach((handler) => { handler(evt); });
+			(all['*'] || []).forEach((handler) => { handler(type, evt); });
 		}
 	};
 }


### PR DESCRIPTION
hello,
this patch tries to remove some seemingly unnecessary intermediary copies of the listeners array created twice by `slice()` and `map()` on each `emit` invocation.
As a side note, this shaves a few bytes from `mitt.js` (310B -> 302B), but the gzip size remains unchanged.