### PR TITLE
cache map.get() for size wins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,21 +27,22 @@ export interface Emitter {
  *  @name mitt
  *  @returns {Mitt}
  */
-export default function mitt(all: EventHandlerMap): Emitter {
+export default function mitt(all?: EventHandlerMap): Emitter {
 	all = all || new Map();
 
 	return {
 		/**
 		 * Register an event handler for the given type.
-		 *
 		 * @param {string|symbol} type Type of event to listen for, or `"*"` for all events
 		 * @param {Function} handler Function to call in response to given event
 		 * @memberOf mitt
 		 */
 		on(type: EventType, handler: Handler) {
-			const handlers = all.get(type) || [];
-			handlers.push(handler);
-			all.set(type, handlers);
+			const handlers = all.get(type);
+			const added = handlers && handlers.push(handler);
+			if (!added) {
+				all.set(type, [handler]);
+			}
 		},
 
 		/**
@@ -52,9 +53,9 @@ export default function mitt(all: EventHandlerMap): Emitter {
 		 * @memberOf mitt
 		 */
 		off(type: EventType, handler: Handler) {
-			const list = all.get(type);
-			if (list) {
-				list.splice(list.indexOf(handler) >>> 0, 1);
+			const handlers = all.get(type);
+			if (handlers) {
+				handlers.splice(handlers.indexOf(handler) >>> 0, 1);
 			}
 		},
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export default function mitt(all: EventHandlerMap): Emitter {
 		 * @memberOf mitt
 		 */
 		on(type: EventType, handler: Handler) {
-			const handlers = (all.get(type) || []);
+			const handlers = all.get(type) || [];
 			handlers.push(handler);
 			all.set(type, handlers);
 		},
@@ -52,8 +52,9 @@ export default function mitt(all: EventHandlerMap): Emitter {
 		 * @memberOf mitt
 		 */
 		off(type: EventType, handler: Handler) {
-			if (all.has(type)) {
-				all.get(type).splice(all.get(type).indexOf(handler) >>> 0, 1);
+			const list = all.get(type);
+			if (list) {
+				list.splice(list.indexOf(handler) >>> 0, 1);
 			}
 		},
 


### PR DESCRIPTION
This is a follow-up to #99 that reduces size a bit by caching the result of `handlers.get()` and reusing that value for both the existence check (are any handlers registered) and the index calculation.