### PR TITLE
Export Mitt types for TS consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "umd:main": "dist/mitt.umd.js",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "testonly": "mocha --require esm --require ts-node/register test/**/*.js",
+    "test": "npm-run-all --silent typecheck lint testonly",
+    "testonly": "mocha --require esm test/**/*.js",
     "lint": "eslint src test --ext ts --ext js",
-    "test": "tsc src/index.ts --noEmit && npm run lint && npm run testonly",
+    "typecheck": "tsc **/*.ts --noEmit",
     "bundle": "microbundle",
     "build": "npm-run-all --silent clean -p bundle -s docs",
     "clean": "rimraf dist",
@@ -23,6 +24,7 @@
   "keywords": [
     "events",
     "eventemitter",
+    "emitter",
     "pubsub"
   ],
   "homepage": "https://github.com/developit/mitt",
@@ -47,6 +49,7 @@
     "env": {
       "browser": true,
       "mocha": true,
+      "jest": false,
       "es6": true
     },
     "globals": {
@@ -57,12 +60,16 @@
         2,
         "always"
       ],
+      "jest/valid-expect": 0,
       "@typescript-eslint/no-explicit-any": 0,
       "@typescript-eslint/explicit-function-return-type": 0,
       "@typescript-eslint/explicit-module-boundary-types": 0,
       "@typescript-eslint/no-empty-function": 0
     }
   },
+  "eslintIgnore": [
+    "dist"
+  ],
   "devDependencies": {
     "@types/chai": "^4.2.11",
     "@types/mocha": "^7.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
-type EventType = string | symbol;
+export type EventType = string | symbol;
 
 // An event handler can take an optional event argument
 // and should not return a value
-type Handler = (event?: any) => void;
-type WildcardHandler= (type: EventType, event?: any) => void
+export type Handler = (event?: any) => void;
+export type WildcardHandler= (type: EventType, event?: any) => void
 
 // An array of all currently registered event handlers for a type
-type EventHandlerList = Array<Handler>;
-type WildCardEventHandlerList = Array<WildcardHandler>;
+export type EventHandlerList = Array<Handler>;
+export type WildCardEventHandlerList = Array<WildcardHandler>;
 
 // A map of event types and their corresponding event handlers.
-type EventHandlerMap = Map<EventType, EventHandlerList | WildCardEventHandlerList>;
+export type EventHandlerMap = Map<EventType, EventHandlerList | WildCardEventHandlerList>;
 
 export interface Emitter {
 	on(type: EventType, handler: Handler): void;

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,25 @@
-import mitt from '../src';
+import mitt from '..';
 import chai, { expect } from 'chai';
 import { spy } from 'sinon';
 import sinonChai from 'sinon-chai';
 chai.use(sinonChai);
 
-it('should default export be a function', () => {
-	expect(mitt).to.be.a('function');
+describe('mitt', () => {
+	it('should default export be a function', () => {
+		expect(mitt).to.be.a('function');
+	});
+
+	it('should accept an optional event handler map', () => {
+		expect(() => mitt(new Map())).not.to.throw;
+		const map = new Map();
+		const a = spy();
+		const b = spy();
+		map.set('foo', [a, b]);
+		const events = mitt(map);
+		events.emit('foo');
+		expect(a).to.have.been.calledOnce;
+		expect(b).to.have.been.calledOnce;
+	});
 });
 
 describe('mitt#', () => {

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,20 @@
+import mitt, { EventHandlerList, EventHandlerMap } from '..';
+
+const events = mitt();
+function foo() {}
+events.on('foo', foo);
+events.emit('foo', 'hello');
+
+// handler return type should be ignored:
+events.on('foo', async e => e * 42);
+
+// event map type
+const map = new Map<string, EventHandlerList>([
+	['foo', [foo]]
+]);
+const events2 = mitt(map);
+events2.emit('foo', 'hello');
+
+// event map type & iterables
+const map2 : EventHandlerMap = new Map(Object.entries(({ foo: [foo] })));
+mitt(map2);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compileOnSave": false,
+	"compilerOptions": {
+		"noEmit": true,
+		"declaration": true,
+		"moduleResolution": "node",
+		"strict": true
+	},
+	"exclude": [
+		"test"
+	]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"noEmit": true,
 		"declaration": true,
-		"moduleResolution": "node",
-		"strict": true
+		"moduleResolution": "node"
 	},
 	"exclude": [
 		"test"


### PR DESCRIPTION
Without this change you can't access or use the TypeScript types from
Mitt when consuming the library. Apologies, I missed this in the first pass.