### PR TITLE
Add clear() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ const emitter: mitt.Emitter = mitt();
     -   [Parameters](#parameters-1)
 -   [emit](#emit)
     -   [Parameters](#parameters-2)
+-   [clear](#clear)
 
 ### mitt
 
@@ -141,6 +142,12 @@ Note: Manually firing "\*" handlers is not supported.
 
 -   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** The event type to invoke
 -   `evt` **Any?** Any value (object is recommended and powerful), passed to each handler
+
+### clear
+
+Remove all event handlers.
+
+Note: This will also remove event handlers passed via `mitt(all: EventHandlerMap)`.
 
 ## Contribute
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ export interface Emitter {
 
 	emit<T = any>(type: EventType, event?: T): void;
 	emit(type: '*', event?: any): void;
+
+	clear(): void;
 }
 
 /** Mitt: Tiny (~200b) functional event emitter / pubsub.
@@ -73,6 +75,15 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 		emit(type: EventType, evt: any) {
 			((all.get(type) || []) as EventHandlerList).slice().map((handler) => { handler(evt); });
 			((all.get('*') || []) as WildCardEventHandlerList).slice().map((handler) => { handler(type, evt); });
+		},
+
+		/**
+		 * Remove all event handlers.
+		 *
+		 * Note: This will also remove event handlers passed via `mitt(all: EventHandlerMap)`.
+		 */
+		clear() {
+			all.clear();
 		}
 	};
 }

--- a/test/index.js
+++ b/test/index.js
@@ -179,4 +179,22 @@ describe('mitt#', () => {
 			expect(star).to.have.been.calledOnce.and.calledWith('bar', eb);
 		});
 	});
+
+	describe('clear()', () => {
+		it('should be a function', () => {
+			expect(inst)
+				.to.have.property('clear')
+				.that.is.a('function');
+		});
+
+		it('should remove existing handlers', () => {
+			const foo = () => {};
+			const bar = () => {};
+			inst.on('foo', foo);
+			inst.on('bar', bar);
+			inst.clear();
+			expect(events.get('foo')).to.be.undefined;
+			expect(events.size).to.equal(0);
+		});
+	});
 });


### PR DESCRIPTION
### Description 

Adds a `clear()` function, as discussed in https://github.com/developit/mitt/pull/72#issuecomment-361379479.

As noted in https://github.com/developit/mitt/pull/72#issuecomment-422786692, implementing a "clear all events"-functionality via `off()` can be problematic, since events passed in the mitt `all`-param will get removed.   
The `clear()`-method is more expressive in what it does.

Is an alternative to #105.

### Is `Map.clear()` supported by all major browsers?

Yes. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear

### Relates to

#70 #72 #102