### PR TITLE
Expose `all` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ emitter.on('*', (type, e) => console.log(type, e) )
 // fire an event
 emitter.emit('foo', { a: 'b' })
 
+// clearing all events
+emitter.all.clear()
+
 // working with handler references:
 function onFoo() {}
 emitter.on('foo', onFoo)   // listen
@@ -99,11 +102,13 @@ const emitter: mitt.Emitter = mitt();
 #### Table of Contents
 
 -   [mitt](#mitt)
--   [on](#on)
-    -   [Parameters](#parameters)
--   [off](#off)
-    -   [Parameters](#parameters-1)
 -   [emit](#emit)
+    -   [Properties](#properties)
+-   [emit](#emit-1)
+    -   [Parameters](#parameters)
+-   [on](#on)
+    -   [Parameters](#parameters-1)
+-   [off](#off)
     -   [Parameters](#parameters-2)
 
 ### mitt
@@ -111,6 +116,24 @@ const emitter: mitt.Emitter = mitt();
 Mitt: Tiny (~200b) functional event emitter / pubsub.
 
 Returns **Mitt** 
+
+### emit
+
+#### Properties
+
+-   `all` **EventHandlerMap** Contains all registered event handlers.
+
+### emit
+
+Invoke all handlers for the given type.
+If present, `"*"` handlers are invoked after type-matched handlers.
+
+Note: Manually firing "\*" handlers is not supported.
+
+#### Parameters
+
+-   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** The event type to invoke
+-   `evt` **Any?** Any value (object is recommended and powerful), passed to each handler
 
 ### on
 
@@ -129,18 +152,6 @@ Remove an event handler for the given type.
 
 -   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** Type of event to unregister `handler` from, or `"*"`
 -   `handler` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Handler function to remove
-
-### emit
-
-Invoke all handlers for the given type.
-If present, `"*"` handlers are invoked after type-matched handlers.
-
-Note: Manually firing "\*" handlers is not supported.
-
-#### Parameters
-
--   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** The event type to invoke
--   `evt` **Any?** Any value (object is recommended and powerful), passed to each handler
 
 ## Contribute
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ export type WildCardEventHandlerList = Array<WildcardHandler>;
 export type EventHandlerMap = Map<EventType, EventHandlerList | WildCardEventHandlerList>;
 
 export interface Emitter {
+	all: EventHandlerMap;
+
 	on(type: EventType, handler: Handler): void;
 	on(type: '*', handler: WildcardHandler): void;
 
@@ -30,7 +32,12 @@ export interface Emitter {
 export default function mitt(all?: EventHandlerMap): Emitter {
 	all = all || new Map();
 
+	/**
+	 * @property {EventHandlerMap} all Contains all registered event handlers.
+	 */
 	return {
+
+		all,
 
 		/**
 		 * Register an event handler for the given type.

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,14 @@ describe('mitt#', () => {
 		inst = mitt(events);
 	});
 
+	describe('properties', () => {
+		it('should expose the event handler map', () => {
+			expect(inst)
+				.to.have.property('all')
+				.that.is.a('map');
+		});
+	});
+
 	describe('on()', () => {
 		it('should be a function', () => {
 			expect(inst)


### PR DESCRIPTION
### Description 

Exposes the `all` property. (Although I would prefer calling it `listeners`.)

This makes it possible to clear all events by executing `mittInstance.all.clear()`.

Is a (lightweight) alternative to #104.

### Relates to

#70 #72 #102 