### PR TITLE
Remove trailing space

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ const emitter: mitt.Emitter = mitt();
 
 Mitt: Tiny (~200b) functional event emitter / pubsub.
 
-Returns **Mitt** 
+Returns **Mitt**
 
 ### on
 


### PR DESCRIPTION
Background: our DevTools presubmit checks warn about this every time we roll our Puppeteer dep.