### PR TITLE
Possible Optimizations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,9 +27,7 @@ export interface Emitter {
  *  @name mitt
  *  @returns {Mitt}
  */
-export default function mitt(all?: EventHandlerMap): Emitter {
-	all = all || new Map();
-
+export default function mitt(all: EventHandlerMap = new Map()): Emitter {
 	return {
 
 		/**
@@ -71,8 +69,8 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 		 * @memberOf mitt
 		 */
 		emit(type: EventType, evt: any) {
-			((all.get(type) || []) as EventHandlerList).slice().map((handler) => { handler(evt); });
-			((all.get('*') || []) as WildCardEventHandlerList).slice().map((handler) => { handler(type, evt); });
+			((all.get(type) || []) as EventHandlerList).forEach((handler) => { handler(evt); });
+			((all.get('*') || []) as WildCardEventHandlerList).forEach((handler) => { handler(type, evt); });
 		}
 	};
 }


### PR DESCRIPTION
1.  slice().map() creates two new arrays whereas forEach just iterates the existing arrays of handlers

2. using an initializer for `all` saves a line where you had `all = all || new Map()`

Hope this helps!  Love how minimal it is! 😄