### PR TITLE
Stronger typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 package-lock.json
 .DS_Store
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -80,9 +80,17 @@ emitter.off('foo', onFoo)  // unlisten
 
 ### Typescript
 
+Set `"strict": true` in your tsconfig.json to get improved type inferrence for `mitt` instance methods.
+
 ```ts
 import mitt from 'mitt';
-const emitter: mitt.Emitter = mitt();
+
+type Events = {
+  foo: string
+  bar?: number
+}
+
+const emitter: mitt.Emitter<Events> = mitt<Events>();
 ```
 
 ## Examples & Demos
@@ -114,7 +122,7 @@ const emitter: mitt.Emitter = mitt();
 
 Mitt: Tiny (~200b) functional event emitter / pubsub.
 
-Returns **Mitt** 
+Returns **Mitt**
 
 ### all
 
@@ -126,7 +134,7 @@ Register an event handler for the given type.
 
 #### Parameters
 
--   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** Type of event to listen for, or `"*"` for all events
+-   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** Type of event to listen for, or `'*'` for all events
 -   `handler` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Function to call in response to given event
 
 ### off
@@ -135,15 +143,15 @@ Remove an event handler for the given type.
 
 #### Parameters
 
--   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** Type of event to unregister `handler` from, or `"*"`
+-   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** Type of event to unregister `handler` from, or `'*'`
 -   `handler` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Handler function to remove
 
 ### emit
 
 Invoke all handlers for the given type.
-If present, `"*"` handlers are invoked after type-matched handlers.
+If present, `'*'` handlers are invoked after type-matched handlers.
 
-Note: Manually firing "\*" handlers is not supported.
+Note: Manually firing '\*' handlers is not supported.
 
 #### Parameters
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ const emitter: mitt.Emitter<Events> = mitt<Events>();
 
 Mitt: Tiny (~200b) functional event emitter / pubsub.
 
-Returns **Mitt**
+Returns **Mitt** 
 
 ### all
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ emitter.off('foo', onFoo)  // unlisten
 
 ### Typescript
 
-Set `"strict": true` in your tsconfig.json to get improved type inferrence for `mitt` instance methods.
+Set `"strict": true` in your tsconfig.json to get improved type inference for `mitt` instance methods.
 
 ```ts
 import mitt from 'mitt';
@@ -122,7 +122,7 @@ const emitter: mitt.Emitter<Events> = mitt<Events>();
 
 Mitt: Tiny (~200b) functional event emitter / pubsub.
 
-Returns **Mitt** 
+Returns **Mitt**
 
 ### all
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "npm-run-all --silent typecheck lint mocha test-types",
     "mocha": "mocha test",
-    "test-types": "tsc test/test-types-compilation.ts --noEmit",
+    "test-types": "tsc test/test-types-compilation.ts --noEmit --strict",
     "lint": "eslint src test --ext ts --ext js",
     "typecheck": "tsc --noEmit",
     "bundle": "microbundle",
@@ -78,7 +78,8 @@
       "@typescript-eslint/no-explicit-any": 0,
       "@typescript-eslint/explicit-function-return-type": 0,
       "@typescript-eslint/explicit-module-boundary-types": 0,
-      "@typescript-eslint/no-empty-function": 0
+      "@typescript-eslint/no-empty-function": 0,
+      "@typescript-eslint/no-non-null-assertion": 0
     }
   },
   "eslintIgnore": [
@@ -104,6 +105,9 @@
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "ts-node": "^8.10.2",
-    "typescript": "^3.9.3"
+    "typescript": "^3.9.7"
+  },
+  "dependencies": {
+    "ts-toolbelt": "^6.13.37"
   }
 }

--- a/package.json
+++ b/package.json
@@ -106,8 +106,5 @@
     "sinon-chai": "^3.5.0",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.7"
-  },
-  "dependencies": {
-    "ts-toolbelt": "^6.13.37"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,38 @@
+import { Union } from 'ts-toolbelt';
+
 export type EventType = string | symbol;
 
 // An event handler can take an optional event argument
 // and should not return a value
-export type Handler<T = any> = (event?: T) => void;
-export type WildcardHandler = (type: EventType, event?: any) => void;
+export type Handler<T = unknown> = (event: T) => void;
+export type WildcardHandler<T = Record<string, unknown>> = (
+	type: keyof T,
+	event: T[keyof T]
+) => void;
 
 // An array of all currently registered event handlers for a type
-export type EventHandlerList = Array<Handler>;
-export type WildCardEventHandlerList = Array<WildcardHandler>;
+export type EventHandlerList<T = unknown> = Array<Handler<T>>;
+export type WildCardEventHandlerList<T = Record<string, unknown>> = Array<WildcardHandler<T>>;
 
 // A map of event types and their corresponding event handlers.
-export type EventHandlerMap = Map<EventType, EventHandlerList | WildCardEventHandlerList>;
+export type EventHandlerMap<Events extends Record<EventType, unknown>> = Map<
+	keyof Events | '*',
+	EventHandlerList<Events[keyof Events]> | WildCardEventHandlerList<Events>
+>;
 
-export interface Emitter {
-	all: EventHandlerMap;
+export interface Emitter<Events extends Record<EventType, unknown>> {
+	all: EventHandlerMap<Events>;
 
-	on<T = any>(type: EventType, handler: Handler<T>): void;
-	on(type: '*', handler: WildcardHandler): void;
+	on<Key extends keyof Events>(type: Key, handler: Handler<Events[Key]>): void;
+	on(type: '*', handler: WildcardHandler<Events>): void;
 
-	off<T = any>(type: EventType, handler: Handler<T>): void;
-	off(type: '*', handler: WildcardHandler): void;
+	off<Key extends keyof Events>(type: Key, handler: Handler<Events[Key]>): void;
+	off(type: '*', handler: WildcardHandler<Events>): void;
 
-	emit<T = any>(type: EventType, event?: T): void;
-	emit(type: '*', event?: any): void;
+	emit<Key extends keyof Events>(type: Key, event: Events[Key]): void;
+	emit<Key extends keyof Events>(
+		type: Union.Has<Events[Key], undefined> extends 1 ? Key : never
+	): void;
 }
 
 /**
@@ -30,7 +40,12 @@ export interface Emitter {
  * @name mitt
  * @returns {Mitt}
  */
-export default function mitt(all?: EventHandlerMap): Emitter {
+export default function mitt<Events extends Record<EventType, unknown>>(
+	all?: EventHandlerMap<Events>
+): Emitter<Events> {
+	type GenericEventHandler =
+		| Handler<Events[keyof Events]>
+		| WildcardHandler<Events>;
 	all = all || new Map();
 
 	return {
@@ -42,26 +57,26 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 
 		/**
 		 * Register an event handler for the given type.
-		 * @param {string|symbol} type Type of event to listen for, or `"*"` for all events
+		 * @param {string|symbol} type Type of event to listen for, or `'*'` for all events
 		 * @param {Function} handler Function to call in response to given event
 		 * @memberOf mitt
 		 */
-		on<T = any>(type: EventType, handler: Handler<T>) {
-			const handlers = all.get(type);
+		on<Key extends keyof Events>(type: Key, handler: GenericEventHandler) {
+			const handlers: Array<GenericEventHandler> | undefined = all!.get(type);
 			const added = handlers && handlers.push(handler);
 			if (!added) {
-				all.set(type, [handler]);
+				all!.set(type, [handler] as EventHandlerList<Events[keyof Events]>);
 			}
 		},
 
 		/**
 		 * Remove an event handler for the given type.
-		 * @param {string|symbol} type Type of event to unregister `handler` from, or `"*"`
+		 * @param {string|symbol} type Type of event to unregister `handler` from, or `'*'`
 		 * @param {Function} handler Handler function to remove
 		 * @memberOf mitt
 		 */
-		off<T = any>(type: EventType, handler: Handler<T>) {
-			const handlers = all.get(type);
+		off<Key extends keyof Events>(type: Key, handler: GenericEventHandler) {
+			const handlers: Array<GenericEventHandler> | undefined = all!.get(type);
 			if (handlers) {
 				handlers.splice(handlers.indexOf(handler) >>> 0, 1);
 			}
@@ -69,17 +84,25 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 
 		/**
 		 * Invoke all handlers for the given type.
-		 * If present, `"*"` handlers are invoked after type-matched handlers.
+		 * If present, `'*'` handlers are invoked after type-matched handlers.
 		 *
-		 * Note: Manually firing "*" handlers is not supported.
+		 * Note: Manually firing '*' handlers is not supported.
 		 *
 		 * @param {string|symbol} type The event type to invoke
 		 * @param {Any} [evt] Any value (object is recommended and powerful), passed to each handler
 		 * @memberOf mitt
 		 */
-		emit<T = any>(type: EventType, evt: T) {
-			((all.get(type) || []) as EventHandlerList).slice().map((handler) => { handler(evt); });
-			((all.get('*') || []) as WildCardEventHandlerList).slice().map((handler) => { handler(type, evt); });
+		emit<Key extends keyof Events>(type: Key, evt?: Events[Key]) {
+			((all!.get(type) || []) as EventHandlerList<Events[keyof Events]>)
+				.slice()
+				.map((handler) => {
+					handler(evt!);
+				});
+			((all!.get('*') || []) as WildCardEventHandlerList<Events>)
+				.slice()
+				.map((handler) => {
+					handler(type, evt!);
+				});
 		}
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Union } from 'ts-toolbelt';
+import { Union, B } from 'ts-toolbelt';
 
 export type EventType = string | symbol;
 
@@ -31,7 +31,7 @@ export interface Emitter<Events extends Record<EventType, unknown>> {
 
 	emit<Key extends keyof Events>(type: Key, event: Events[Key]): void;
 	emit<Key extends keyof Events>(
-		type: Union.Has<Events[Key], undefined> extends 1 ? Key : never
+		type: Union.Has<Events[Key], undefined> extends B.True ? Key : never
 	): void;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { Union, B } from 'ts-toolbelt';
-
 export type EventType = string | symbol;
 
 // An event handler can take an optional event argument
@@ -30,9 +28,7 @@ export interface Emitter<Events extends Record<EventType, unknown>> {
 	off(type: '*', handler: WildcardHandler<Events>): void;
 
 	emit<Key extends keyof Events>(type: Key, event: Events[Key]): void;
-	emit<Key extends keyof Events>(
-		type: Union.Has<Events[Key], undefined> extends B.True ? Key : never
-	): void;
+	emit<Key extends keyof Events>(type: undefined extends Events[Key] ? Key : never): void;
 }
 
 /**

--- a/test/index_test.ts
+++ b/test/index_test.ts
@@ -1,4 +1,4 @@
-import mitt, { Emitter } from '..';
+import mitt, { Emitter, EventHandlerMap } from '..';
 import chai, { expect } from 'chai';
 import { spy } from 'sinon';
 import sinonChai from 'sinon-chai';
@@ -15,7 +15,7 @@ describe('mitt', () => {
 		const a = spy();
 		const b = spy();
 		map.set('foo', [a, b]);
-		const events = mitt(map);
+		const events = mitt<{ foo: undefined }>(map);
 		events.emit('foo');
 		expect(a).to.have.been.calledOnce;
 		expect(b).to.have.been.calledOnce;
@@ -23,9 +23,21 @@ describe('mitt', () => {
 });
 
 describe('mitt#', () => {
-	let events, inst: Emitter;
+	const eventType = Symbol('eventType');
+	type Events = {
+		foo: unknown;
+		constructor: unknown;
+		FOO: unknown;
+		bar: unknown;
+		Bar: unknown;
+		'baz:bat!': unknown;
+		'baz:baT!': unknown;
+		Foo: unknown;
+		[eventType]: unknown;
+	};
+	let events: EventHandlerMap<Events>, inst: Emitter<Events>;
 
-	beforeEach( () => {
+	beforeEach(() => {
 		events = new Map();
 		inst = mitt(events);
 	});
@@ -83,7 +95,6 @@ describe('mitt#', () => {
 
 		it('can take symbols for event types', () => {
 			const foo = () => {};
-			const eventType = Symbol('eventType');
 			inst.on(eventType, foo);
 			expect(events.get(eventType)).to.deep.equal([foo]);
 		});
@@ -151,7 +162,7 @@ describe('mitt#', () => {
 		it('should invoke handler for type', () => {
 			const event = { a: 'b' };
 
-			inst.on('foo', (one, two?) => {
+			inst.on('foo', (one, two?: unknown) => {
 				expect(one).to.deep.equal(event);
 				expect(two).to.be.an('undefined');
 			});

--- a/test/test-types-compilation.ts
+++ b/test/test-types-compilation.ts
@@ -13,7 +13,7 @@ const emitter = mitt<{
 }>();
 
 const barHandler = (x?: number) => {};
-const fooHandler = (x?: string) => {};
+const fooHandler = (x: string) => {};
 const wildcardHandler = (
 	_type: 'foo' | 'bar' | 'someEvent',
 	_event: string | SomeEventData | number | undefined

--- a/test/test-types-compilation.ts
+++ b/test/test-types-compilation.ts
@@ -2,42 +2,77 @@
 
 import mitt from '..';
 
-const emitter = mitt();
+interface SomeEventData {
+	name: string;
+}
+
+const emitter = mitt<{
+	foo: string;
+	someEvent: SomeEventData;
+	bar?: number;
+}>();
+
+const barHandler = (x?: number) => {};
+const fooHandler = (x?: string) => {};
+const wildcardHandler = (
+	_type: 'foo' | 'bar' | 'someEvent',
+	_event: string | SomeEventData | number | undefined
+) => {};
 
 /*
- * Check that if on is provided a generic, it only accepts handlers of that type
+ * Check that 'on' args are inferred correctly
  */
 {
-	const badHandler = (x: number) => {};
-	const goodHandler = (x: string) => {};
+	// @ts-expect-error
+	emitter.on('foo', barHandler);
+	emitter.on('foo', fooHandler);
+
+	emitter.on('bar', barHandler);
+	// @ts-expect-error
+	emitter.on('bar', fooHandler);
+
+	emitter.on('*', wildcardHandler);
+	// fooHandler is ok, because ('foo' | 'bar' | 'someEvent') extends string
+	emitter.on('*', fooHandler);
+	// @ts-expect-error
+	emitter.on('*', barHandler);
+}
+
+/*
+ * Check that 'off' args are inferred correctly
+ */
+{
+	// @ts-expect-error
+	emitter.off('foo', barHandler);
+	emitter.off('foo', fooHandler);
+
+	emitter.off('bar', barHandler);
+	// @ts-expect-error
+	emitter.off('bar', fooHandler);
+
+	emitter.off('*', wildcardHandler);
+	// fooHandler is ok, because ('foo' | 'bar' | 'someEvent') extends string
+	emitter.off('*', fooHandler);
+	// @ts-expect-error
+	emitter.off('*', barHandler);
+}
+
+/*
+ * Check that 'emit' args are inferred correctly
+ */
+{
+	// @ts-expect-error
+	emitter.emit('someEvent', 'NOT VALID');
+	emitter.emit('someEvent', { name: 'jack' });
 
 	// @ts-expect-error
-	emitter.on<string>('foo', badHandler);
-	emitter.on<string>('foo', goodHandler);
-}
-
-/*
- * Check that if off is provided a generic, it only accepts handlers of that type
- */
-{
-	const badHandler = (x: number) => {};
-	const goodHandler = (x: string) => {};
-
+	emitter.emit('foo');
 	// @ts-expect-error
-	emitter.off<string>('foo', badHandler);
-	emitter.off<string>('foo', goodHandler);
+	emitter.emit('foo', 1);
+	emitter.emit('foo', 'string');
+
+	emitter.emit('bar');
+	emitter.emit('bar', 1);
+	// @ts-expect-error
+	emitter.emit('bar', 'string');
 }
-
-
-/*
- * Check that if emitt is provided a generic, it only accepts event data of that type
- */
-{
-	interface SomeEventData {
-    name: string;
-  }
-  // @ts-expect-error
-	emitter.emit<SomeEventData>('foo', 'NOT VALID');
-	emitter.emit<SomeEventData>('foo', { name: 'jack' });
-}
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,11 @@
 {
 	"compileOnSave": false,
 	"compilerOptions": {
+		"strict": true,
 		"noEmit": true,
 		"declaration": true,
 		"moduleResolution": "node",
 		"esModuleInterop": true
 	},
-	"include": [
-		"src/*.ts",
-		"test/*.ts",
-	]
+	"include": ["src/*.ts", "test/*.ts"]
 }


### PR DESCRIPTION
This PR improves type inference for instance methods when `"strict": true` is present in tsconfig.json. Compiled js code isn't affected by this change, only typings.

```ts
const emitter = mitt<{
  foo: string;
  bar?: number;
}>()

// Error: Type 'string' is not assignable to type 'number'.ts(2769)
emitter.on('foo', (x: number) => {})
// Ok
emitter.on('foo', (x: string) => {})

//Error: Type 'number | undefined' is not assignable to type 'number'.
//          Type 'undefined' is not assignable to type 'number'.ts(2769)
emitter.on('bar', (x: number) => {})
// Ok
emitter.on('bar', (x?: number) => {})

// Error: Argument of type '"foo"' is not assignable to parameter of type 'never'.ts(2345)
emitter.emit('foo')
// Ok
emitter.emit('bar')

// Error: Argument of type '123' is not assignable to parameter of type 'string'.ts(2345)
emitter.emit('foo', 123)
// Ok
emitter.emit('foo', 'string')
// Ok
emitter.emit('bar', 123)
```

fixes #112
fixes #106