### PR TITLE
Update README.md - type import

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ emitter.off('foo', onFoo)  // unlisten
 ### Typescript
 
 ```ts
-import mitt from 'mitt';
-const emitter: mitt.Emitter = mitt();
+import mitt, { Emitter } from 'mitt';
+const emitter: Emitter = mitt();
 ```
 
 ## Examples & Demos


### PR DESCRIPTION
```javascript
import mitt from 'mitt';
const emitter: mitt.Emitter = mitt();
```
Will complain
`TS2503: Cannot find namespace 'mitt'.`