### PR TITLE
If emitter.off provides only the event, remove all listeners for that event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Register an event handler for the given type.
 ### off
 
 Remove an event handler for the given type.
+If omit the `handler`, all event handlers of the given type are deleted.
 
 #### Parameters
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export interface Emitter {
 	on<T = any>(type: EventType, handler: Handler<T>): void;
 	on(type: '*', handler: WildcardHandler): void;
 
-	off<T = any>(type: EventType, handler: Handler<T>): void;
+	off<T = any>(type: EventType, handler?: Handler<T>): void;
 	off(type: '*', handler: WildcardHandler): void;
 
 	emit<T = any>(type: EventType, event?: T): void;
@@ -60,10 +60,14 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 		 * @param {Function} handler Handler function to remove
 		 * @memberOf mitt
 		 */
-		off<T = any>(type: EventType, handler: Handler<T>) {
+		off<T = any>(type: EventType, handler?: Handler<T>) {
 			const handlers = all.get(type);
 			if (handlers) {
+		            if(handler){
 				handlers.splice(handlers.indexOf(handler) >>> 0, 1);
+		            } else {
+		                all.delete(type);
+		            }
 			}
 		},
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 
 		/**
 		 * Remove an event handler for the given type.
+		 * If omit the `handler`, all event handlers of the given type are deleted.
 		 * @param {string|symbol} type Type of event to unregister `handler` from, or `"*"`
 		 * @param {Function} handler Handler function to remove
 		 * @memberOf mitt
@@ -63,11 +64,12 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 		off<T = any>(type: EventType, handler?: Handler<T>) {
 			const handlers = all.get(type);
 			if (handlers) {
-		            if(handler){
-				handlers.splice(handlers.indexOf(handler) >>> 0, 1);
-		            } else {
-		                all.delete(type);
-		            }
+				if (handler) {
+					handlers.splice(handlers.indexOf(handler) >>> 0, 1);
+				}
+				else {
+					all.delete(type);
+				}
 			}
 		},
 


### PR DESCRIPTION
This solves the #123 issue.
```
		off<T = any>(type: EventType, handler?: Handler<T>) {
			const handlers = all.get(type);
			if (handlers) {
		            if(handler){
				handlers.splice(handlers.indexOf(handler) >>> 0, 1);
		            } else {
		                all.delete(type);
		            }
			}
		},
```