### PR TITLE
Arbitrary number of emit() arguments using rest/spread

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,9 +77,9 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 		 * @param {Any} [evt] Any value (object is recommended and powerful), passed to each handler
 		 * @memberOf mitt
 		 */
-		emit<T = any>(type: EventType, evt: T) {
-			((all.get(type) || []) as EventHandlerList).slice().map((handler) => { handler(evt); });
-			((all.get('*') || []) as WildCardEventHandlerList).slice().map((handler) => { handler(type, evt); });
+		emit<T = any>(type: EventType, ...evt: T[]) {
+			((all.get(type) || []) as EventHandlerList).slice().map((handler) => { handler(...evt); });
+			((all.get('*') || []) as WildCardEventHandlerList).slice().map((handler) => { handler(type, ...evt); });
 		}
 	};
 }

--- a/test/index_test.ts
+++ b/test/index_test.ts
@@ -186,5 +186,13 @@ describe('mitt#', () => {
 			inst.emit('bar', eb);
 			expect(star).to.have.been.calledOnce.and.calledWith('bar', eb);
 		});
+
+		it('spreaded arguments', () => {
+			const Func = spy();
+			events.set('Func', [Func]);
+
+			inst.emit('Func', ...[1,2,3]);
+			expect(Func).to.have.been.called.and.calledWith(1,2,3);
+		});
 	});
 });


### PR DESCRIPTION
#115 