### PR TITLE
Ignore src directory publish to prevent typescript error

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+src
+test
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,14 +31,14 @@ export interface Emitter {
  * @returns {Mitt}
  */
 export default function mitt(all?: EventHandlerMap): Emitter {
-	all = all || new Map();
+	const allEvents = all || new Map();
 
 	return {
 
 		/**
 		 * A Map of event names to registered handler functions.
 		 */
-		all,
+		all: allEvents,
 
 		/**
 		 * Register an event handler for the given type.
@@ -47,10 +47,10 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 		 * @memberOf mitt
 		 */
 		on<T = any>(type: EventType, handler: Handler<T>) {
-			const handlers = all.get(type);
+			const handlers = allEvents.get(type);
 			const added = handlers && handlers.push(handler);
 			if (!added) {
-				all.set(type, [handler]);
+				allEvents.set(type, [handler]);
 			}
 		},
 
@@ -61,7 +61,7 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 		 * @memberOf mitt
 		 */
 		off<T = any>(type: EventType, handler: Handler<T>) {
-			const handlers = all.get(type);
+			const handlers = allEvents.get(type);
 			if (handlers) {
 				handlers.splice(handlers.indexOf(handler) >>> 0, 1);
 			}
@@ -78,8 +78,8 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 		 * @memberOf mitt
 		 */
 		emit<T = any>(type: EventType, evt: T) {
-			((all.get(type) || []) as EventHandlerList).slice().map((handler) => { handler(evt); });
-			((all.get('*') || []) as WildCardEventHandlerList).slice().map((handler) => { handler(type, evt); });
+			((allEvents.get(type) || []) as EventHandlerList).slice().map((handler) => { handler(evt); });
+			((allEvents.get('*') || []) as WildCardEventHandlerList).slice().map((handler) => { handler(type, evt); });
 		}
 	};
 }


### PR DESCRIPTION
The typescript will import the src/index and throw errors at run tsc when setting `module` as 'ESNEXT' of the tsconfig.
Even if sets the `skipLibCheck` as true

![image](https://user-images.githubusercontent.com/7475347/109944419-2d213880-7d11-11eb-8e84-c049294098a3.png)
