### PR TITLE
cheaper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,9 +77,12 @@ export default function mitt(all?: EventHandlerMap): Emitter {
 		 * @param {Any} [evt] Any value (object is recommended and powerful), passed to each handler
 		 * @memberOf mitt
 		 */
-		emit<T = any>(type: EventType, evt: T) {
-			((all.get(type) || []) as EventHandlerList).slice().map((handler) => { handler(evt); });
-			((all.get('*') || []) as WildCardEventHandlerList).slice().map((handler) => { handler(type, evt); });
+		emit<T = any>(type: EventType, evt?: T) {
+			let handlers = all.get(type);
+			handlers && (handlers as EventHandlerList).slice().map((handler) => { handler(evt); });
+
+			handlers = all.get('*');
+			handlers && (handlers as WildCardEventHandlerList).slice().map((handler) => { handler(type, evt); });
 		}
 	};
 }


### PR DESCRIPTION
before
```
Build "mitt" to dist:
        187 B: mitt.js.gz       
        159 B: mitt.js.br       
        186 B: mitt.es.js.gz    
        161 B: mitt.es.js.br    
        183 B: mitt.modern.js.gz
        158 B: mitt.modern.js.br
        267 B: mitt.umd.js.gz   
        231 B: mitt.umd.js.br
```
after
```
Build "mitt" to dist:
        182 B: mitt.js.gz       
        152 B: mitt.js.br       
        181 B: mitt.es.js.gz    
        153 B: mitt.es.js.br    
        181 B: mitt.modern.js.gz
        154 B: mitt.modern.js.br
        261 B: mitt.umd.js.gz
        225 B: mitt.umd.js.br
```

If this PR is approved / merge, please consider #124 (Will not exceed 200b), consider the following application scenarios.
```
// listen
emitter.on('foo', () => {}) 

// unlisten
emitter.off('foo')
```
