### PR TITLE
[TS] Return unsub() from on()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,13 +58,14 @@ export default function mitt<Events extends Record<EventType, unknown>>(
 		 * @memberOf mitt
 		 */
 		on<Key extends keyof Events>(type: Key, handler: GenericEventHandler) {
-			const handlers: Array<GenericEventHandler> | undefined = all!.get(type);
-			if (handlers) {
-				handlers.push(handler);
+			let handlers: Array<GenericEventHandler> | undefined = all!.get(type);
+			if (!handlers) {
+				all!.set(type, handlers = []);
 			}
-			else {
-				all!.set(type, [handler] as EventHandlerList<Events[keyof Events]>);
-			}
+			handlers.push(handler);
+			return () => {
+				handlers!.splice(handlers!.indexOf(handler) >>> 0, 1);
+			};
 		},
 
 		/**
@@ -75,13 +76,13 @@ export default function mitt<Events extends Record<EventType, unknown>>(
 		 * @memberOf mitt
 		 */
 		off<Key extends keyof Events>(type: Key, handler?: GenericEventHandler) {
-			const handlers: Array<GenericEventHandler> | undefined = all!.get(type);
+			let handlers: Array<GenericEventHandler> | undefined = all!.get(type);
 			if (handlers) {
 				if (handler) {
 					handlers.splice(handlers.indexOf(handler) >>> 0, 1);
 				}
 				else {
-					all!.set(type, []);
+					all!.set(type, handlers = []);
 				}
 			}
 		},


### PR DESCRIPTION
This is another take on the proposed behavior from #42, where `on()` returns a function that can be called to remove the added listener.

My concerns remain, however, and I don't think this should be landed. Any implementation that provides this convenience makes it easier to create memory leaks, because there are now two separate owners of a given handler reference - Mitt itself, and the app code that added the listener.