### PR TITLE
Add clear method

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ emitter.on('*', (type, e) => console.log(type, e) )
 emitter.emit('foo', { a: 'b' })
 
 // clearing all events
-emitter.all.clear()
+emitter.clear()
 
 // working with handler references:
 function onFoo() {}
@@ -134,6 +134,7 @@ const emitter: Emitter<Events> = mitt<Events>();
     -   [Parameters](#parameters-1)
 -   [emit](#emit)
     -   [Parameters](#parameters-2)
+-  [clear](#clear)
 
 ### mitt
 
@@ -175,6 +176,10 @@ Note: Manually firing '\*' handlers is not supported.
 
 -   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** The event type to invoke
 -   `evt` **Any?** Any value (object is recommended and powerful), passed to each handler
+
+### clear
+
+Clear all event listeners
 
 ## Contribute
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ export interface Emitter<Events extends Record<EventType, unknown>> {
 
 	emit<Key extends keyof Events>(type: Key, event: Events[Key]): void;
 	emit<Key extends keyof Events>(type: undefined extends Events[Key] ? Key : never): void;
+
+	clear(): void;
 }
 
 /**
@@ -114,6 +116,14 @@ export default function mitt<Events extends Record<EventType, unknown>>(
 						handler(type, evt!);
 					});
 			}
+		},
+
+		/**
+		 * Clear all
+		 * @memberOf mitt
+		 */
+		clear() {
+			all?.clear();
 		}
 	};
 }

--- a/test/index_test.ts
+++ b/test/index_test.ts
@@ -209,4 +209,18 @@ describe('mitt#', () => {
 			expect(star).to.have.been.calledOnce.and.calledWith('bar', eb);
 		});
 	});
+
+	describe('clear()', () => {
+		it('should be a function', () => {
+			expect(inst)
+				.to.have.property('clear')
+				.that.is.a('function');
+		});
+		it('should clear all', () => {
+			inst.on('foo', () => {});
+			inst.on('bar', () => {});
+			inst.clear();
+			expect(events.size).to.equal(0);
+		});
+	});
 });


### PR DESCRIPTION
I thought it would be more intuitive to return a clear method, so I did so.