### PR TITLE
chore: add tsconfig target option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compileOnSave": false,
 	"compilerOptions": {
+		"target": "ESNext",
 		"strict": true,
 		"noEmit": true,
 		"declaration": true,


### PR DESCRIPTION
If the `target` attribute is not added, the map will display a type error message in `typescript`