### PR TITLE
Feat/support dual esm cjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist
+/types-*
 /test-reports
 /node_modules
 /npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /dist
-/types-*
 /test-reports
 /node_modules
 /npm-debug.log

--- a/README.md
+++ b/README.md
@@ -10,22 +10,22 @@
 
 > Tiny 200b functional event emitter / pubsub.
 
--   **Microscopic:** weighs less than 200 bytes gzipped
--   **Useful:** a wildcard `"*"` event type listens to all events
--   **Familiar:** same names & ideas as [Node's EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)
--   **Functional:** methods don't rely on `this`
--   **Great Name:** somehow [mitt](https://npm.im/mitt) wasn't taken
+*   **Microscopic:** weighs less than 200 bytes gzipped
+*   **Useful:** a wildcard `"*"` event type listens to all events
+*   **Familiar:** same names & ideas as [Node's EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)
+*   **Functional:** methods don't rely on `this`
+*   **Great Name:** somehow [mitt](https://npm.im/mitt) wasn't taken
 
 Mitt was made for the browser, but works in any JavaScript runtime. It has no dependencies and supports IE9+.
 
 ## Table of Contents
 
--   [Install](#install)
--   [Usage](#usage)
--   [Examples & Demos](#examples--demos)
--   [API](#api)
--   [Contribute](#contribute)
--   [License](#license)
+*   [Install](#install)
+*   [Usage](#usage)
+*   [Examples & Demos](#examples--demos)
+*   [API](#api)
+*   [Contribute](#contribute)
+*   [License](#license)
 
 ## Install
 
@@ -118,7 +118,7 @@ const emitter: Emitter<Events> = mitt<Events>();
   <img src="https://i.imgur.com/CjBgOfJ.png" width="278" alt="preact + mitt preview">
 </a>
 
-* * *
+***
 
 ## API
 
@@ -126,20 +126,20 @@ const emitter: Emitter<Events> = mitt<Events>();
 
 #### Table of Contents
 
--   [mitt](#mitt)
--   [all](#all)
--   [on](#on)
-    -   [Parameters](#parameters)
--   [off](#off)
-    -   [Parameters](#parameters-1)
--   [emit](#emit)
-    -   [Parameters](#parameters-2)
+*   [mitt](#mitt)
+*   [all](#all)
+*   [on](#on)
+    *   [Parameters](#parameters)
+*   [off](#off)
+    *   [Parameters](#parameters-1)
+*   [emit](#emit)
+    *   [Parameters](#parameters-2)
 
 ### mitt
 
 Mitt: Tiny (~200b) functional event emitter / pubsub.
 
-Returns **Mitt** 
+Returns **Mitt**&#x20;
 
 ### all
 
@@ -151,8 +151,8 @@ Register an event handler for the given type.
 
 #### Parameters
 
--   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** Type of event to listen for, or `'*'` for all events
--   `handler` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Function to call in response to given event
+*   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** Type of event to listen for, or `'*'` for all events
+*   `handler` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Function to call in response to given event
 
 ### off
 
@@ -161,8 +161,8 @@ If `handler` is omitted, all handlers of the given type are removed.
 
 #### Parameters
 
--   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** Type of event to unregister `handler` from, or `'*'`
--   `handler` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?** Handler function to remove
+*   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** Type of event to unregister `handler` from (`'*'` to remove a wildcard handler)
+*   `handler` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?** Handler function to remove
 
 ### emit
 
@@ -173,8 +173,8 @@ Note: Manually firing '\*' handlers is not supported.
 
 #### Parameters
 
--   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** The event type to invoke
--   `evt` **Any?** Any value (object is recommended and powerful), passed to each handler
+*   `type` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol))** The event type to invoke
+*   `evt` **Any?** Any value (object is recommended and powerful), passed to each handler
 
 ## Contribute
 
@@ -190,15 +190,15 @@ If don't, just open a [new clear and descriptive issue](../../issues/new).
 
 Pull requests are the greatest contributions, so be sure they are focused in scope, and do avoid unrelated commits.
 
--   Fork it!
--   Clone your fork: `git clone https://github.com/<your-username>/mitt`
--   Navigate to the newly cloned directory: `cd mitt`
--   Create a new branch for the new feature: `git checkout -b my-new-feature`
--   Install the tools necessary for development: `npm install`
--   Make your changes.
--   Commit your changes: `git commit -am 'Add some feature'`
--   Push to the branch: `git push origin my-new-feature`
--   Submit a pull request with full remarks documenting your changes.
+*   Fork it!
+*   Clone your fork: `git clone https://github.com/<your-username>/mitt`
+*   Navigate to the newly cloned directory: `cd mitt`
+*   Create a new branch for the new feature: `git checkout -b my-new-feature`
+*   Install the tools necessary for development: `npm install`
+*   Make your changes.
+*   Commit your changes: `git commit -am 'Add some feature'`
+*   Push to the branch: `git push origin my-new-feature`
+*   Submit a pull request with full remarks documenting your changes.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@liammartens/mitt",
-  "version": "3.0.1-beta.3",
+  "name": "mitt",
+  "version": "3.0.1",
   "description": "Tiny 200b functional Event Emitter / pubsub.",
   "source": "src/index.ts",
   "module": "dist/esm/mitt.mjs",

--- a/package.json
+++ b/package.json
@@ -6,15 +6,15 @@
   "module": "dist/esm/mitt.mjs",
   "main": "dist/cjs/mitt.js",
   "umd:main": "dist/mitt.umd.js",
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/esm/mitt.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/esm/index.d.ts",
+        "types": "./dist/esm/mitt.d.ts",
         "default": "./dist/esm/mitt.mjs"
       },
       "require": {
-        "types": "./dist/cjs/index.d.ts",
+        "types": "./dist/cjs/mitt.d.ts",
         "default": "./dist/cjs/mitt.js"
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,19 +1,23 @@
 {
-  "name": "mitt",
-  "version": "3.0.1",
+  "name": "@liammartens/mitt",
+  "version": "3.0.1-beta.3",
   "description": "Tiny 200b functional Event Emitter / pubsub.",
-  "module": "dist/mitt.mjs",
-  "main": "dist/mitt.js",
-  "jsnext:main": "dist/mitt.mjs",
-  "umd:main": "dist/mitt.umd.js",
   "source": "src/index.ts",
-  "typings": "index.d.ts",
+  "module": "dist/esm/mitt.mjs",
+  "main": "dist/cjs/mitt.js",
+  "umd:main": "dist/mitt.umd.js",
+  "types": "dist/esm/index.d.ts",
   "exports": {
-    "types": "./index.d.ts",
-    "module": "./dist/mitt.mjs",
-    "import": "./dist/mitt.mjs",
-    "require": "./dist/mitt.js",
-    "default": "./dist/mitt.mjs"
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/mitt.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/mitt.js"
+      }
+    }
   },
   "scripts": {
     "test": "npm-run-all --silent typecheck lint mocha test-types",
@@ -21,8 +25,10 @@
     "test-types": "tsc test/test-types-compilation.ts --noEmit --strict",
     "lint": "eslint src test --ext ts --ext js",
     "typecheck": "tsc --noEmit",
-    "bundle": "microbundle -f es,cjs,umd",
-    "build": "npm-run-all --silent clean -p bundle -s docs",
+    "bundle:cjs": "tsup --config ./tsup.config.cjs.ts",
+    "bundle:esm": "tsup --config ./tsup.config.esm.ts",
+    "bundle:umd": "tsup --config ./tsup.config.umd.ts",
+    "build": "npm-run-all --silent clean -p bundle:* -s docs && tsconfig-to-dual-package ./tsconfig.cjs.json ./tsconfig.esm.json",
     "clean": "rimraf dist",
     "docs": "documentation readme src/index.ts --section API -q --parse-extension ts",
     "release": "npm run -s build -s && npm t && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
@@ -40,8 +46,7 @@
   ],
   "license": "MIT",
   "files": [
-    "dist",
-    "index.d.ts"
+    "dist"
   ],
   "mocha": {
     "extension": [
@@ -80,6 +85,8 @@
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "tsconfig-to-dual-package": "^1.2.0",
+    "tsup": "^8.0.1",
+    "typescript": "^5.0.0"
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "CommonJS",
+    "moduleResolution": "Node10",
+		"outDir": "dist/cjs"
+	}
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "ESNext",
+    "outDir": "dist/esm"
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,10 @@
 		"strict": true,
 		"noEmit": true,
 		"declaration": true,
-		"moduleResolution": "node",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
 		"skipLibCheck": true,
-		"esModuleInterop": true,
+		"esModuleInterop": true
 	},
-	"include": [
-		"src/*.ts",
-		"test/*.ts"
-	]
+	"include": ["src/*.ts", "test/*.ts"]
 }

--- a/tsup.config.cjs.ts
+++ b/tsup.config.cjs.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: {
+		mitt: 'src/index.ts'
+	},
+	format: 'cjs',
+	outDir: 'dist/cjs',
+	dts: true,
+	tsconfig: './tsconfig.cjs.json',
+	target: 'safari11',
+	splitting: true,
+	sourcemap: true,
+	cjsInterop: true,
+	clean: true
+});

--- a/tsup.config.esm.ts
+++ b/tsup.config.esm.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: {
+		mitt: 'src/index.ts'
+	},
+	format: 'esm',
+	outDir: 'dist/esm',
+	dts: true,
+	tsconfig: './tsconfig.esm.json',
+	target: 'safari11',
+	splitting: false,
+	sourcemap: true,
+	clean: true
+});

--- a/tsup.config.umd.ts
+++ b/tsup.config.umd.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: {
+		mitt: 'src/index.ts'
+	},
+	format: 'iife',
+	outDir: 'dist',
+	globalName: 'mitt',
+	target: 'safari11',
+	splitting: false,
+	sourcemap: true,
+	clean: true,
+	outExtension: () => ({ js: '.umd.js' }),
+	footer: () => ({
+		js: 'Object.assign(window,{mitt:mitt.default})'
+	})
+});


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [x] Other, please explain: Fixes problem with dual publishing of library and `NodeNext` moduleResolution (#191)

#### What changes did you make? (Give an overview)
Updated the build

#### Is there anything you'd like reviewers to focus on?
As far as I can tell, the new artifacts are functionally identical. Both the ESM and CJS outputs support default importing/requiring.
```
import mitt from 'mitt' // works
const mitt = require('mitt') // works
```