### PR TITLE
Add `this: void` to all methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,17 +23,27 @@ export type EventHandlerMap<Events extends Record<EventType, unknown>> = Map<
 export interface Emitter<Events extends Record<EventType, unknown>> {
 	all: EventHandlerMap<Events>;
 
-	on<Key extends keyof Events>(type: Key, handler: Handler<Events[Key]>): void;
-	on(type: '*', handler: WildcardHandler<Events>): void;
+	on<Key extends keyof Events>(
+		this: void,
+		type: Key,
+		handler: Handler<Events[Key]>
+	): void;
+	on(this: void, type: '*', handler: WildcardHandler<Events>): void;
 
 	off<Key extends keyof Events>(
+		this: void,
 		type: Key,
 		handler?: Handler<Events[Key]>
 	): void;
-	off(type: '*', handler: WildcardHandler<Events>): void;
+	off(this: void, type: '*', handler: WildcardHandler<Events>): void;
 
-	emit<Key extends keyof Events>(type: Key, event: Events[Key]): void;
 	emit<Key extends keyof Events>(
+		this: void,
+		type: Key,
+		event: Events[Key]
+	): void;
+	emit<Key extends keyof Events>(
+		this: void,
 		type: undefined extends Events[Key] ? Key : never
 	): void;
 }
@@ -63,7 +73,11 @@ export default function mitt<Events extends Record<EventType, unknown>>(
 		 * @param {Function} handler Function to call in response to given event
 		 * @memberOf mitt
 		 */
-		on<Key extends keyof Events>(type: Key, handler: GenericEventHandler) {
+		on<Key extends keyof Events>(
+			this: void,
+			type: Key,
+			handler: GenericEventHandler
+		) {
 			const handlers: Array<GenericEventHandler> | undefined = all!.get(type);
 			if (handlers) {
 				handlers.push(handler);
@@ -79,7 +93,11 @@ export default function mitt<Events extends Record<EventType, unknown>>(
 		 * @param {Function} [handler] Handler function to remove
 		 * @memberOf mitt
 		 */
-		off<Key extends keyof Events>(type: Key, handler?: GenericEventHandler) {
+		off<Key extends keyof Events>(
+			this: void,
+			type: Key,
+			handler?: GenericEventHandler
+		) {
 			const handlers: Array<GenericEventHandler> | undefined = all!.get(type);
 			if (handlers) {
 				if (handler) {
@@ -100,7 +118,7 @@ export default function mitt<Events extends Record<EventType, unknown>>(
 		 * @param {Any} [evt] Any value (object is recommended and powerful), passed to each handler
 		 * @memberOf mitt
 		 */
-		emit<Key extends keyof Events>(type: Key, evt?: Events[Key]) {
+		emit<Key extends keyof Events>(this: void, type: Key, evt?: Events[Key]) {
 			let handlers = all!.get(type);
 			if (handlers) {
 				(handlers as EventHandlerList<Events[keyof Events]>)


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

When destructuring an instantiated emitter, the [typescript-eslint rule `unbound-method`](https://typescript-eslint.io/rules/unbound-method/) reports these cases:

```ts
const { emit, on, off } = mitt()
//      ^^^^  ^^  ^^^
// Avoid referencing unbound methods which may cause unintentional scoping of `this`.
// If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
```

Since `this` is not accessed inside mitt, this PR adds the [`this: void` annotation](https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function) to the `emit`, `on` and `off` methods.

#### Is there anything you'd like reviewers to focus on?

No.

#### Does this PR introduce a breaking change? (What changes might other developers need to make in their application due to this PR?)

No.