### PR TITLE
feat: added a signal for unsubscribing on abort

### DIFF
--- a/test/index_test.ts
+++ b/test/index_test.ts
@@ -103,6 +103,43 @@ describe('mitt#', () => {
 			inst.on('foo', foo);
 			expect(events.get('foo')).to.deep.equal([foo, foo]);
 		});
+
+		it('should unsubscribe when signal aborted', () => {
+			const foo = spy();
+			const abortController = new AbortController();
+
+			inst.on(
+				'foo',
+				foo,
+				{ signal: abortController.signal }
+			);
+			inst.emit('foo');
+
+			abortController.abort();
+
+			inst.emit('foo');
+
+			expect(foo).to.have.been.callCount(1);
+		});
+
+		it('should make multiple unsubscribe when aborted', () => {
+			const foo = spy();
+			const bar = spy();
+			const abortController = new AbortController();
+
+			inst.on('foo', foo, { signal: abortController.signal });
+			inst.on('bar', bar, { signal: abortController.signal });
+			inst.emit('foo');
+			inst.emit('bar');
+
+			abortController.abort();
+
+			inst.emit('foo');
+			inst.emit('bar');
+
+			expect(foo).to.have.been.callCount(1);
+			expect(bar).to.have.been.callCount(1);
+		});
 	});
 
 	describe('off()', () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [X] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)
I added an optional parameter to the "on" function that can unsubscribe when an abortion event occurs.

#### Is there anything you'd like reviewers to focus on?
I don't know if it was worth adding SubscribeParams to the function signature `on(type: '*'...)`

#### Does this PR introduce a breaking change? (What changes might other developers need to make in their application due to this PR?)
This pull request does not contain any bracking changes.